### PR TITLE
go-redis/redis integration added

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2018, OpenCensus Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ocredis/example_test.go
+++ b/ocredis/example_test.go
@@ -1,0 +1,103 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocredis_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/go-redis/redis"
+	ocredis "github.com/orijtech/go-opencensus-integrations/ocredis"
+
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/trace"
+)
+
+type printExporter int
+
+func (pe *printExporter) ExportSpan(sd *trace.SpanData) {
+	fmt.Printf("\nSpanData:\nName: %s\nTraceID: %x\nSpanID: %x\nParentSpanID: %x\n\n",
+		sd.Name, sd.TraceID, sd.SpanID, sd.ParentSpanID)
+}
+
+var pe = new(printExporter)
+
+func Example_PerCommandTracer() {
+	// Just some pre-requisites to demo the interaction
+	// between OpenCensus and the integration.
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(pe)
+	defer trace.UnregisterExporter(pe)
+
+	client := redis.NewClient(&redis.Options{Addr: ":6379"})
+	client.WrapProcess(ocredis.PerCommandTracer(context.Background()))
+	_, err := client.HMSet("names", map[string]interface{}{
+		"space": 1961, "tracing": "OpenCensus",
+		"monitoring": "OpenCensus",
+	}).Result()
+	if err != nil {
+		log.Fatalf("Failed to HMSet: %v", err)
+	}
+}
+
+func Example_NewClient() {
+	// Just some pre-requisites to demo the interaction
+	// between OpenCensus and the integration.
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(pe)
+	defer trace.UnregisterExporter(pe)
+
+	// Create and use the client
+	client := ocredis.NewClient(context.Background(), ":6379")
+	if _, err := client.HSet("programs", "space", 1961).Result(); err != nil {
+		log.Fatalf("HSet error: %v", err)
+	}
+}
+
+func Example_NewClient_comprehensive() {
+	// Just some pre-requisites to demo the interaction
+	// between OpenCensus and the integration.
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+	trace.RegisterExporter(pe)
+	defer trace.UnregisterExporter(pe)
+
+	ctx := context.Background()
+	// Now. Download the website
+	req, _ := http.NewRequest("POST", "https://example.org/", nil)
+	req = req.WithContext(ctx)
+	res, err := (&http.Client{Transport: &ochttp.Transport{}}).Do(req)
+	if err != nil {
+		log.Fatalf("Failed to retrieve response: %v", err)
+	}
+	blob, err := ioutil.ReadAll(res.Body)
+	_ = res.Body.Close()
+
+	// Then cache if for later use
+	client := ocredis.NewClient(ctx, ":6379")
+	if _, err := client.HSet("cached", "example.org", blob).Result(); err != nil {
+		log.Fatalf("Failed to cache website: %v", err)
+	}
+
+	// Later use, a client fetching the cached version of the website.
+	client = ocredis.NewClient(ctx, ":6379")
+	cached, err := client.HGet("cached", "example.org").Result()
+	if err != nil {
+		log.Fatalf("Failed to lookup from cache: %v", err)
+	}
+	log.Printf("%s", cached)
+}

--- a/ocredis/ocredis.go
+++ b/ocredis/ocredis.go
@@ -1,0 +1,60 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocredis
+
+import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/trace"
+
+	"github.com/go-redis/redis"
+)
+
+// NewClient creates a trace instrumented redis.Client.
+// It takes context.Context as a first argument because
+// clients can cheaply be created an discarded, and for a
+// full trace you'll want to create a client that uses the provided
+// context. For example:
+//    req, _ := http.NewRequest()
+//    req = req.WithContext(ctx)
+//    ...
+//    client := NewClient(req.Context(), redisAddr)
+//    client.HMSet("results", keyValueDict)
+func NewClient(ctx context.Context, addr string) *redis.Client {
+	client := redis.NewClient(&redis.Options{
+		Addr: addr,
+	}).WithContext(ctx)
+
+	client.WrapProcess(PerCommandTracer(client.Context()))
+	return client
+}
+
+// PerCommandTracer provides the instrumented WrapProcess function that you can attach to any
+// client. It specifically takes in a context.Context as the first argument because
+// you could be using the same client but wrapping it in a different context.
+func PerCommandTracer(ctx context.Context) func(oldProcess func(cmd redis.Cmder) error) func(redis.Cmder) error {
+	return func(fn func(cmd redis.Cmder) error) func(redis.Cmder) error {
+		return func(cmd redis.Cmder) error {
+			_, span := trace.StartSpan(ctx, fmt.Sprintf("redis-go/%s", cmd.Name()))
+			err := fn(cmd)
+			if err != nil {
+				span.SetStatus(trace.Status{Code: int32(trace.StatusCodeUnknown), Message: err.Error()})
+			}
+			span.End()
+			return err
+		}
+	}
+}


### PR DESCRIPTION
Added a `go-redis/redis` integration. See
`ocredis/examples_test.go` for sample usage such as
this website caching sample with Redis:

```go
package main

import (
	"context"
	"fmt"
	"io/ioutil"
	"log"
	"net/http"

	"github.com/go-redis/redis"
	ocredis "github.com/orijtech/go-opencensus-integrations/ocredis"

	"go.opencensus.io/plugin/ochttp"
	"go.opencensus.io/trace"
)

type printExporter int

func (pe *printExporter) ExportSpan(sd *trace.SpanData) {
	fmt.Printf("\nSpanData:\nName: %s\nTraceID: %x\nSpanID: %x\nParentSpanID: %x\n\n",
		sd.Name, sd.TraceID, sd.SpanID, sd.ParentSpanID)
}

var pe = new(printExporter)

func main() {
	// Just some pre-requisites to demo the interaction
	// between OpenCensus and the integration.
	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
	trace.RegisterExporter(pe)
	defer trace.UnregisterExporter(pe)

	ctx := context.Background()
	// Now. Download the website
	req, _ := http.NewRequest("POST", "https://example.org/", nil)
	req = req.WithContext(ctx)
	res, err := (&http.Client{Transport: &ochttp.Transport{}}).Do(req)
	if err != nil {
		log.Fatalf("Failed to retrieve response: %v", err)
	}
	blob, err := ioutil.ReadAll(res.Body)
	_ = res.Body.Close()

	// Then cache if for later use
	client := ocredis.NewClient(ctx, ":6379")
	if _, err := client.HSet("cached", "example.org", blob).Result(); err != nil {
		log.Fatalf("Failed to cache website: %v", err)
	}

	// Later use, a client fetching the cached version of the website.
	client = ocredis.NewClient(ctx, ":6379")
	cached, err := client.HGet("cached", "example.org").Result()
	if err != nil {
		log.Fatalf("Failed to lookup from cache: %v", err)
	}
	log.Printf("%s", cached)
}
```